### PR TITLE
Fix: qSVG polygonize - polygons creation condition

### DIFF
--- a/qSVG.js
+++ b/qSVG.js
@@ -739,7 +739,7 @@ var qSVG = {
                   coords.push({x: vertex[tempSurface[rr]].x, y: vertex[tempSurface[rr]].y});
                 }
                 // WARNING -> FAKE
-                if (realCoords.inside.length != realCoords.outside) {
+                if (realCoords.inside.length != realCoords.outside.length) {
                   polygons.push({way: tempSurface, coords: coords, coordsOutside: realCoords.outside, coordsInside: realCoords.inside, area: realArea, outsideArea: outsideArea, realArea: bestArea});
                 }
                 else { // REAL INSIDE POLYGONE -> ROOM


### PR DESCRIPTION
## 🐞Current Issue
A condition in the `qSVG.polygonize()` method always resolves to `true` because it compares an array(`realCoords.outside`) with a number(`realCoords.inside.length`). This leads to incorrect handling of detected polygons.
## ✅Test Steps
1) Start the app from `master` branch
2) Create a basic square floorplan from initial modal
3) Click _**CONFIG. ROOMS**_ option in the left panel
4) Hover over the room

🔎You should see a yellow-highlighted room area. Currently, its edges run through the **center** of the walls.
✅Our intended behavior is for the room area to match the **interior** edges of the walls. This commit fixes that.
## 🛠️`polygonize()` Method Overview
The goal of the `polygonize()` method is to detect polygonal regions by analyzing wall segments and constructing a graph in which it detects closed loops. These loops are evaluated, and if they meet certain conditions (not marked with `bypass = 1`), they are pushed into the `polygons` array as candidates for rooms.
The condition in question is intended to verify whether the detected loop forms a _proper room polygon_. This is also hinted in the inline comment:
> `// REAL INSIDE POLYGONE -> ROOM`

The check attempts to confirm that the loop is symmetrical and well-formed by comparing the `inside` and `outside` coordinate sets. If both arrays have the same length, it suggests a clean, closed shape, and `realCoords.inside` can be trusted.
If they don't match, the method still includes the shape, but uses a fallback approach by using `coords` array. These fallback polygons can still be useful, but are considered less reliable with lower confidence and precision compared to the properly closed loops. They can be interpreted as approximated closed shapes that might not perfectly align with actual room boundaries.
## ✅Proposed fix
Update the condition to correctly compare the **lengths** of the `inside` and `outside` arrays:

> `if (realCoords.inside.length != realCoords.outside.length)`

This simple fix aligns with the original intent, and ensures proper validation of real, symmetrical room polygons.

_We all make typos - it's part of writing software!_